### PR TITLE
Bump update-dotnet-sdk action

### DIFF
--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: dev
-    - uses: martincostello/update-dotnet-sdk@67d6e2b14939c06978a7f80444157296c3defe14 # v3.2.3
+    - uses: martincostello/update-dotnet-sdk@76e2c0df2303d4f6a404228105ebb7d60ace0556 # v3.4.0
       with:
         quality: 'daily'
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bump the update-dotnet-sdk action to v3.4.0 to pick up changes to react to dotnet/core#9671.
